### PR TITLE
Add Category Links to page

### DIFF
--- a/PortalGenerator.ps1
+++ b/PortalGenerator.ps1
@@ -43,11 +43,9 @@ class AdminPortalItem : HTMLImageLink {
 
 class AdminPortalPage {
     [AdminPortalItem[]]$Database
-    [boolean]$IncludeCategoryLinks
 
-    AdminPortalPage([boolean]$IncludeCategoryLinks) {
-        $this.IncludeCategoryLinks = $IncludeCategoryLinks
-    }
+    AdminPortalPage() { }
+
     [void]AddRecord([AdminPortalItem]$Record) {
         $this.Database += $Record
     }
@@ -57,9 +55,7 @@ class AdminPortalPage {
     [string[]]EncapsulateCategory([string]$key) {
         [AdminPortalItem[]]$recordSet = $this.GetRecordsByCategory($key)
         $build = @()
-        if ($this.IncludeCategoryLinks) {
-            $build += "<a id=`"$key`"></a>"
-        }
+        $build += "<a id=`"$key`"></a>"
         $build += '<p class="grid-container-label">' + $key + '</p>'
         $build += '<div class="grid-container">'
         foreach ($Record in $recordSet) {
@@ -72,6 +68,9 @@ class AdminPortalPage {
         return ($this.Database).Category | Sort-Object | Select-Object -Unique
     }
     [string[]]GetHtml() {
+        return $this.GetHtml($false)
+    }
+    [string[]]GetHtml([boolean]$IncludeCategoryLinks = $false) {
         $Build = @()
         $build += '<!DOCTYPE html>'
         $build += '<html>'
@@ -79,7 +78,7 @@ class AdminPortalPage {
         $build += '<link rel="stylesheet" type="text/css" href="index.css">'
         $build += '</head>'
         $build += '<body>'
-        if ($this.IncludeCategoryLinks) {
+        if ($IncludeCategoryLinks) {
             $build += '<p class="grid-container-label">'
             $build += ($this.GetAllCategoriesInSet() | ForEach-Object { "<a href=`"#$_`">$_</a>" }) -join ' | '
             $build += '</p>'
@@ -94,11 +93,17 @@ class AdminPortalPage {
 }
 
 
-$DB = [AdminPortalPage]::new($IncludeCategoryLinks)
+$DB = [AdminPortalPage]::new()
 
 $LoadConfig = Get-Content -Path $ConfigFile | ConvertFrom-Csv
 foreach ($Config in $LoadConfig) {
     $DB.AddRecord([AdminPortalItem]::new($config.Category, $config.ALTText, $config.Image, $config.URI))
 }
 
-$db.GetHtml() | Set-Content -Path $WebSiteFile
+if ($IncludeCategoryLinks) {
+    # Should work true or false
+    $db.GetHtml($IncludeCategoryLinks) | Set-Content -Path $WebSiteFile
+}
+else {
+    $db.GetHtml() | Set-Content -Path $WebSiteFile
+}

--- a/PortalGenerator.ps1
+++ b/PortalGenerator.ps1
@@ -1,8 +1,9 @@
 #Admin Portal Generator
-    param(
-        [parameter(Mandatory)][validateNotNullOrEmpty()][string]$ConfigFile,
-        [parameter(Mandatory)][validateNotNullOrEmpty()][string]$WebSiteFile
-    )
+param(
+    [parameter(Mandatory)][validateNotNullOrEmpty()][string]$ConfigFile,
+    [parameter(Mandatory)][validateNotNullOrEmpty()][string]$WebSiteFile,
+    [parameter()][switch]$IncludeCategoryLinks
+)
 
 
 class HTMLImageLink {
@@ -10,23 +11,23 @@ class HTMLImageLink {
     [string]$URI
     [string]$Image
     hidden [boolean]$NewTab
-    HTMLImageLink ([string]$ALTText,[string]$URI,[string]$Image,[boolean]$NewTab){
+    HTMLImageLink ([string]$ALTText, [string]$URI, [string]$Image, [boolean]$NewTab) {
         $this.ALTText = $ALTText
         $this.URI = $URI
         $this.Image = $Image
         $this.NewTab = $NewTab
     }
-    [string]GetTargetCode(){
-        if ($this.NewTab) { return ' target="_blank"'} else { return ""}
+    [string]GetTargetCode() {
+        if ($this.NewTab) { return ' target="_blank"' } else { return "" }
     }
-    [string]GetHTML(){
+    [string]GetHTML() {
         return "<a href=`"$($this.URI)`"$($this.GetTargetCode())><img src=`"$($this.Image)`" class=`"grid-icon`" alt=`"$($this.ALTText)`"></a>"
     }
 }
- 
-class AdminPortalItem : HTMLImageLink{
-    [string]$Category    
-    AdminPortalItem([string]$Category,[string]$Label,    [string]$Image,    [string]$URI) : base ($Label,$URI,$Image,$true){
+
+class AdminPortalItem : HTMLImageLink {
+    [string]$Category
+    AdminPortalItem([string]$Category, [string]$Label, [string]$Image, [string]$URI) : base ($Label, $URI, $Image, $true) {
         $this.Category = $Category
     }
     [string[]]GetHTML() {
@@ -37,22 +38,28 @@ class AdminPortalItem : HTMLImageLink{
         $build += ' </div>'
         return $build
     }
-    
+
 }
 
 class AdminPortalPage {
     [AdminPortalItem[]]$Database
-    AdminPortalPage(){
+    [boolean]$IncludeCategoryLinks
+
+    AdminPortalPage([boolean]$IncludeCategoryLinks) {
+        $this.IncludeCategoryLinks = $IncludeCategoryLinks
     }
-    [void]AddRecord([AdminPortalItem]$Record){
+    [void]AddRecord([AdminPortalItem]$Record) {
         $this.Database += $Record
     }
-    [AdminPortalItem[]]GetRecordsByCategory([string]$key){
-        return $this.Database.where({$_.Category -eq $key})
+    [AdminPortalItem[]]GetRecordsByCategory([string]$key) {
+        return $this.Database.where( { $_.Category -eq $key })
     }
-    [string[]]EncapsulateCategory([string]$key){
+    [string[]]EncapsulateCategory([string]$key) {
         [AdminPortalItem[]]$recordSet = $this.GetRecordsByCategory($key)
         $build = @()
+        if ($this.IncludeCategoryLinks) {
+            $build += "<a id=`"$key`"></a>"
+        }
         $build += '<p class="grid-container-label">' + $key + '</p>'
         $build += '<div class="grid-container">'
         foreach ($Record in $recordSet) {
@@ -61,7 +68,7 @@ class AdminPortalPage {
         $build += '</div>'
         return $build
     }
-    [string[]]GetAllCategoriesInSet(){
+    [string[]]GetAllCategoriesInSet() {
         return ($this.Database).Category | Sort-Object | Select-Object -Unique
     }
     [string[]]GetHtml() {
@@ -72,6 +79,11 @@ class AdminPortalPage {
         $build += '<link rel="stylesheet" type="text/css" href="index.css">'
         $build += '</head>'
         $build += '<body>'
+        if ($this.IncludeCategoryLinks) {
+            $build += '<p class="grid-container-label">'
+            $build += ($this.GetAllCategoriesInSet() | ForEach-Object { "<a href=`"#$_`">$_</a>" }) -join ' | '
+            $build += '</p>'
+        }
         foreach ($Category in $this.GetAllCategoriesInSet()) {
             $build += $this.EncapsulateCategory($Category)
         }
@@ -82,11 +94,11 @@ class AdminPortalPage {
 }
 
 
-    $DB = [AdminPortalPage]::new()
+$DB = [AdminPortalPage]::new($IncludeCategoryLinks)
 
-    $LoadConfig = get-content -Path $ConfigFile | Convertfrom-csv 
-    foreach ($Config in $LoadConfig){
-        $DB.AddRecord([AdminPortalItem]::new($config.Category,$config.ALTText,$config.Image,$config.URI))
-    }
+$LoadConfig = Get-Content -Path $ConfigFile | ConvertFrom-Csv
+foreach ($Config in $LoadConfig) {
+    $DB.AddRecord([AdminPortalItem]::new($config.Category, $config.ALTText, $config.Image, $config.URI))
+}
 
-    $db.GetHtml() | Set-Content -Path $WebSiteFile
+$db.GetHtml() | Set-Content -Path $WebSiteFile

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Requirements:
 1. IIS server
 2. A collection of 64x64 pixel icons to represent each portal, hint: start with a default one, and add them over time.
 3. This script that generates the index.htm file
-4. The index.css file, which you may retheme to your pleasure. 
+4. The index.css file, which you may retheme to your pleasure.
 5. The config.csv file, which contains the information for each portal you want to add. I thought CSV would be the best format because alot of admins have this type of information already stored in Excel.
 
-This script when supplied with a configuration CSV file will create a webpage that aggregates administrative web portals. 
+This script when supplied with a configuration CSV file will create a webpage that aggregates administrative web portals.
 
 Each record in the CSV is as follows:
 1. Category: Which tile set the portal link will be grouped in, i.e. Site:LasVegas, or SaaS_Apps
@@ -31,7 +31,12 @@ Each record in the CSV is as follows:
 Put the powershell script in the website folder and run it as a scheduled task, or as needed to refresh the updated CSV.
 
 Sample usage
+
 ```.\PortalGenerator.ps1 -ConfigFile .\config.csv -WebSiteFile .\index.html```
+
+Sample usage, if you want to include shortcuts to different categories at the top of the page
+
+```.\PortalGenerator.ps1 -ConfigFile .\config.csv -WebSiteFile .\index.html -IncludeCategoryLinks```
 
 Screenshot:
 ![1](https://github.com/BronsonMagnan/AdminPortal/blob/master/newCSSSamples.png)


### PR DESCRIPTION
This allows the user to add shortcuts to the top of the generated portal to the different ports by using an optional switch parameter.  Uses existing CSS class for consistent look, but this was mainly for functionality, not looks. 

It would allow a user to run with optional switch -IncludeCategoryLinks.  
```Powershell
.\PortalGenerator.ps1 -ConfigFile .\config.csv -WebSiteFile .\index.html -IncludeCategoryLinks
```

Updated Readme.md to reflect new usage option as well. 

Some editor auto-formatting snuck in as well. 